### PR TITLE
Linux: create SDL window with SDL_WINDOW_VULKAN

### DIFF
--- a/src/callbacks.cpp
+++ b/src/callbacks.cpp
@@ -796,6 +796,8 @@ ultramodern::renderer::WindowHandle create_window(ultramodern::gfx_callbacks_t::
     Uint32 flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
 #if defined(__APPLE__)
     flags |= SDL_WINDOW_METAL;
+#elif defined(__linux__)
+    flags |= SDL_WINDOW_VULKAN;
 #endif
 
     SDL_Rect display{};


### PR DESCRIPTION
## Summary
- On Linux, `create_window()` in `src/callbacks.cpp` now adds `SDL_WINDOW_VULKAN` (matching the `RT64_SDL_WINDOW_VULKAN` path).
- Without it, RT64 fails with `SDL_Vulkan_CreateSurface failed ... The specified window isn't a Vulkan window.` then segfaults after audio init.

## Test
- Debian 13 trixie x86_64, Clang 19, RX 7800 XT (RADV), SDL2 system.
- Configure: `-DWR64_WITH_RUNTIME=ON -DWR64_WITH_RECOMPILED=ON -DWR64_WITH_FRONTEND=ON -DRT64_SDL_WINDOW_VULKAN=ON`
- 25s run: boots `BOOT_UP -> TITLE_SCREEN`, display list rewritten, audio audible, 20fps game / 144Hz present, 1828 textures + 9 tracks, no crash (killed by timeout, still running).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RT64 crashing on Linux by creating the SDL window with `SDL_WINDOW_VULKAN` so Vulkan surface creation no longer fails and segfaults after audio init.

<sup>Written for commit 1bd446bf75600604e8521d73472b4af1e8d69f7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elliotttate/wave-race-64-recomp/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

